### PR TITLE
Removed configuring listen timeout on `AndSon`

### DIFF
--- a/and-son.gemspec
+++ b/and-son.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency("ns-options",        ["~>0.4"])
   gem.add_dependency("sanford-protocol",  ["~>0.2"])
 
   gem.add_development_dependency("assert",        ["~> 0.8"])

--- a/lib/and-son.rb
+++ b/lib/and-son.rb
@@ -1,17 +1,7 @@
-# AndSon's main module provides a convenience method for creating clients
-# (`new`) and supports a few configuration options.
-#
-require 'ns-options'
-
 require 'and-son/client'
 require 'and-son/version'
 
 module AndSon
-  include NsOptions
-
-  options :config do
-    option :listen_timeout, Numeric, :default => 10
-  end
 
   def self.new(*args)
     AndSon::Client.new(*args)

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -11,11 +11,7 @@ class AndSon::Client
     end
     subject{ @client }
 
-    should have_instance_methods :host, :port, :version, :timeout, :call
-
-    should "default it's timeout to AndSon's timeout" do
-      assert_equal AndSon.config.listen_timeout, subject.timeout
-    end
+    should have_instance_methods :host, :port, :version, :call
   end
 
   # the `call` method is tested in the file test/system/making_requests_test.rb,


### PR DESCRIPTION
This removes NsOptions as a dependency and the `listen_timeout` option. Now,
timeouts can be passed directly when calling services or it can be globally set
using the environment variable `ANDSON_REQUEST_TIMEOUT`. The default timeout has
also been bumped up to 60s.

Partially implements #3.

@kellyredding - Wanted to have the "per-call timeouts" and env var going before I went into implementing the behavior the README discussed.
