### PR TITLE
Call runner class for configuring per-call parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ AndSon is a simple Sanford client for Ruby.  It provides an API for calling serv
 client = AndSon.new('127.0.0.1', 8000, 'v1')
 
 # call a service and get its response data:
-user_data = client.call('get_user', { :user_name => 'joetest' })
+user_data = client.call('get_user', {:user_name => 'joetest'})
 ```
 
 ## Calling Services
@@ -17,6 +17,25 @@ user_data = client.call('get_user', { :user_name => 'joetest' })
 To call a service, you first need a client to make the calls.  You define clients by specifying the host's ip address and port plus the version of the API to make calls against.
 
 Once you have your client defined, make service calls using the `call` method.  It will return any response data and raise an exception if anything goes wrong.
+
+### Timeouts
+
+By default, all requests timeout after 60s.  You can override this globally using the `ANDSON_TIMEOUT` env var. You can override this global timeout on a per-call basis by chaining in the `timeout` method.
+
+```ruby
+# timeout this request after 10 seconds
+client.timeout(10).call('get_user', {:user_name => 'joetest'})
+```
+
+When a request times out, a `Sanford::Protocol::TimeoutError` is raised:
+
+```ruby
+begin
+  client.timeout(10).call('get_user', {:user_name => 'joetest'})
+rescue Sanford::Protocol::TimeoutError => err
+  puts "timeout - so sad :("
+end
+```
 
 ### Exception Handling
 
@@ -37,8 +56,8 @@ Each exception knows about the response that raised it:
 begin
   client.call('some_unknown_service')
 rescue AndSon::NotFoundError => err
-  err.response              #=> AndSon::Response ...
-  err.response.status.code  #=> 404
+  err.response       #=> AndSon::Response ...
+  err.response.code  #=> 404
 end
 ```
 
@@ -48,7 +67,7 @@ If you call a service and pass it a block, no exceptions will be raised and the 
 
 ```ruby
 user = client.call('get_user', { :user_name => 'joetest' }) do |response|
-  if response.status.code == 200
+  if response.code == 200
     User.new(response.data)
   else
     NullUser.new

--- a/and-son.gemspec
+++ b/and-son.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency("sanford-protocol",  ["~>0.2"])
+  gem.add_dependency("sanford-protocol",  ["~>0.4"])
 
   gem.add_development_dependency("assert",        ["~> 0.8"])
   gem.add_development_dependency("assert-mocha",  ["~> 0.1"])

--- a/lib/and-son/client.rb
+++ b/lib/and-son/client.rb
@@ -1,58 +1,52 @@
-# AndSon's Client is the primary class for the gem. It is a simple client for
-# communicating with a Sanford server. It takes a host and port (the server to
-# connect to) and the version of the services it wants to make requests against.
-# It's `call` handles making a request and reading the server's response. All
-# requests are limited by a timeout, to keep clients from hanging forever,
-# waiting on a server. If a server doesn't respond within this time limit, an
-# exception is raised.
-#
+require 'ostruct'
 require 'sanford-protocol'
-
 require 'and-son/connection'
 
 module AndSon
 
-  class Client
-    attr_reader :host, :port, :version
+  module CallRunnerMethods
 
-    def initialize(host, port, version)
-      options ||= {}
-      @host, @port = [ host, port ]
-      @version = version
-    end
+    # define methods here to allow configuring call runner params.  be sure to
+    # use `tap` to return whatever instance `self.call_runner` returns so you
+    # can method-chain.  `self.call_runner` returns a new runner instance if
+    # called on a client, but returns the chained instance if called on a runner
 
-    def call(name, params = {}, timeout = nil)
-      timeout ||= (ENV['ANDSON_REQUEST_TIMEOUT'] || 60).to_i
-      connection = AndSon::Connection.new(self.host, self.port, timeout)
-      request = self.request(name, params)
-      connection.write(request.to_hash)
-      if connection.ready_to_read?
-        self.response(connection.read)
-      else
-        raise(AndSon::TimeoutError.new(request, timeout))
-      end
-    ensure
-      connection.close if connection
-    end
-
-    protected
-
-    def request(name, params)
-      Sanford::Protocol::Request.new(self.version, name, params)
-    end
-
-    def response(hash)
-      Sanford::Protocol::Response.parse(hash)
+    def timeout(seconds)
+      self.call_runner.tap{|r| r.timeout_value = seconds.to_f}
     end
 
   end
 
-  class TimeoutError < RuntimeError
-    attr_reader :message
+  class Client < Struct.new(:host, :port, :version)
+    include CallRunnerMethods
 
-    def initialize(request, timeout)
-      @message = "The request, #{request.version.inspect} #{request.name.inspect}, " \
-        "didn't respond in #{timeout} seconds or less."
+    DEFAULT_TIMEOUT = 60 #seconds
+
+    # proxy the call method to the call runner
+    def call(*args, &block); self.call_runner.call(*args, &block); end
+
+    def call_runner
+      # always start with this default CallRunner
+      CallRunner.new({
+        :host    => host,
+        :port    => port,
+        :version => version,
+        :timeout_value => (ENV['ANDSON_TIMEOUT'] || DEFAULT_TIMEOUT).to_f
+      })
+    end
+  end
+
+  class CallRunner < OpenStruct # {:host, :port, :version, :timeout_value}
+    include CallRunnerMethods
+
+    # chain runner methods by returning itself
+    def call_runner; self; end
+
+    def call(name, params = {})
+      AndSon::Connection.new(host, port).open do |connection|
+        connection.write(Sanford::Protocol::Request.new(version, name, params).to_hash)
+        Sanford::Protocol::Response.parse(connection.read(timeout_value))
+      end
     end
   end
 

--- a/lib/and-son/connection.rb
+++ b/lib/and-son/connection.rb
@@ -1,45 +1,31 @@
-# AndSon's Connection class extends the Connection class provided by
-# Sanford-Protocol. Instead of taking a socket directly, it takes just the host
-# and port and creates it's own socket. In addition to doing this, it provides
-# a `ready_to_read?` method which can be used to see if a socket is ready to be
-# read from or not. Connections take a timeout value that will be used in
-# conjuction with `IO.select` to check if a socket is ready to be read from. If
-# a socket is not ready within the time limit, the method returns false.
-#
-# Notes:
-# * TCP_NODELAY is set to disable buffering. In the case of Sanford
-#   communication, we have all the information we need to send up front and
-#   are closing the connection, so it doesn't need to buffer. See
-#   http://linux.die.net/man/7/tcp
-#
-require 'sanford-protocol'
 require 'socket'
+require 'sanford-protocol'
 
 module AndSon
 
-  class Connection < Sanford::Protocol::Connection
-
-    attr_reader :timeout
-
-    def initialize(host, port, timeout)
-      @timeout = timeout
-
-      socket = TCPSocket.new(host, port)
-      socket.setsockopt(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, true)
-      super(socket)
+  class Connection < Struct.new(:host, :port)
+    module NoRequest
+      def self.to_s; "[?]"; end
     end
 
-    # IO.select takes array's of IO objects and returns when one of them is
-    # ready. The first parameter is for IO objects that you want to read from.
-    # In this case, we are waiting for our socket to be ready for reading and
-    # using a timeout to limit how long we wait. If nothing is ready within the
-    # timeout, IO.select returns nil.
-    def ready_to_read?
-      !!IO.select([ @socket ], nil, nil, self.timeout)
+    def open
+      protocol_connection = Sanford::Protocol::Connection.new(tcp_socket)
+      yield protocol_connection if block_given?
+    ensure
+      protocol_connection.close rescue false
     end
 
-    def close
-      @socket.close rescue false
+    private
+
+    # TCP_NODELAY is set to disable buffering. In the case of Sanford
+    # communication, we have all the information we need to send up front and
+    # are closing the connection, so it doesn't need to buffer.
+    # See http://linux.die.net/man/7/tcp
+
+    def tcp_socket
+      TCPSocket.new(host, port).tap do |socket|
+        socket.setsockopt(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, true)
+      end
     end
 
   end

--- a/test/system/making_requests_test.rb
+++ b/test/system/making_requests_test.rb
@@ -1,5 +1,4 @@
 require 'assert'
-
 require 'sanford-protocol/test/helpers'
 
 class MakingRequestsTest < Assert::Context
@@ -42,7 +41,7 @@ class MakingRequestsTest < Assert::Context
     end
 
     should "raise a timeout error" do
-      assert_raises(AndSon::TimeoutError){ @client.call('echo', 'test') }
+      assert_raises(Sanford::Protocol::TimeoutError) { @client.call('echo', 'test') }
     end
   end
 

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -5,13 +5,39 @@ class AndSon::Client
   class BaseTest < Assert::Context
     desc "AndSon::Client"
     setup do
-      @host, @port = [ '0.0.0.0', 8000 ]
-      @version = "v1"
+      @host, @port, @version = '0.0.0.0', 8000, "v1"
       @client = AndSon::Client.new(@host, @port, @version)
     end
     subject{ @client }
 
-    should have_instance_methods :host, :port, :version, :call
+    should have_imeths :host, :port, :version
+    should have_imeths :call_runner, :call, :timeout
+
+    should "know its default call runner" do
+      default_runner = subject.call_runner
+
+      assert_equal @host, default_runner.host
+      assert_equal @port, default_runner.port
+      assert_equal @version, default_runner.version
+      assert_equal 60.0, default_runner.timeout_value
+    end
+
+    should "override the default call runner timeout with an env var" do
+      prev = ENV['ANDSON_TIMEOUT']
+      ENV['ANDSON_TIMEOUT'] = '20'
+
+      assert_equal 20.0, subject.call_runner.timeout_value
+
+      ENV['ANDSON_TIMEOUT'] = prev
+    end
+
+    should "return a CallRunner with a timeout value set #timeout" do
+      runner = subject.timeout(10)
+
+      assert_kind_of AndSon::CallRunner, runner
+      assert_respond_to :call, runner
+      assert_equal 10.0, runner.timeout_value
+    end
   end
 
   # the `call` method is tested in the file test/system/making_requests_test.rb,


### PR DESCRIPTION
Right now, this just covers configuring a timeout value.  The
`CallRunner` class is designed to store up all configuration
needed to run a call and then provide the call method itself.

Every method that sets call runner data should return the call
runner so that methods can be chained.
