### PR TITLE
Added `params` chainable method for defaulting params for all requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,24 @@ rescue Sanford::Protocol::TimeoutError => err
 end
 ```
 
+### Default Params
+
+Similarly to timeouts, all requests default their params to an empty `Hash` (`{}`). This can be overriden using the `params` method.
+
+```ruby
+# add an API key to all requests made by this client, to authorize our client
+client.params({ 'api_key' => 12345 }).call('get_user', {:user_name => 'joetest'})
+```
+
+One thing to be aware of, AndSon has limited ability to 'merge' or 'append' params. For example:
+
+```ruby
+# raises an exception, can't merge a string on to a hash
+client.params({ 'api_key' => 12345 }).call('get_user', 'joetest')
+```
+
+Be aware of this when setting default params and passing additional params with the `call` method. In general, it's recommended to use ruby's `Hash` for the best results.
+
 ### Exception Handling
 
 AndSon raises exceptions when a call responds with a `4xx` or `5xx` response code (see [Sanford Status Codes](https://github.com/redding/sanford-protocol#status-codes) for more on response codes):

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -38,6 +38,28 @@ class AndSon::Client
       assert_respond_to :call, runner
       assert_equal 10.0, runner.timeout_value
     end
+
+    should "return a CallRunner with params_value set using #params" do
+      runner = subject.params({ :api_key => 12345 })
+
+      assert_kind_of AndSon::CallRunner, runner
+      assert_respond_to :call, runner
+      assert_equal({ :api_key => 12345 }, runner.params_value)
+    end
+
+    should "raise an ArgumentError when #params is not passed a Hash" do
+      assert_raises(ArgumentError) do
+        subject.params('test')
+      end
+    end
+
+    should "raise an ArgumentError when #call is not passed a Hash for params" do
+      runner = subject.timeout(0.1) # in case it actually tries to make the request
+
+      assert_raises(ArgumentError) do
+        runner.call('something', 'test')
+      end
+    end
   end
 
   # the `call` method is tested in the file test/system/making_requests_test.rb,


### PR DESCRIPTION
This adds the `params` method as a chainable method for the client. It can be
called to setup the default params used for all requests. This allows a base
client to be setup with params that are desired in all requests. Then the
when using `call` only additional params have to be passed.
