### PR TITLE
Client's will now stringify params hashes

### DIFF
--- a/and-son.gemspec
+++ b/and-son.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency("sanford-protocol",  ["~>0.4"])
+  gem.add_dependency("sanford-protocol",  ["~>0.5"])
 
   gem.add_development_dependency("assert",        ["~>1.0"])
   gem.add_development_dependency("assert-mocha",  ["~>1.0"])

--- a/lib/and-son/client.rb
+++ b/lib/and-son/client.rb
@@ -20,7 +20,13 @@ module AndSon
       if !hash.kind_of?(Hash)
         raise ArgumentError, "expected params to be a Hash instead of a #{hash.class}"
       end
-      self.call_runner.tap{|r| r.params_value.merge!(hash) }
+      self.call_runner.tap{|r| r.params_value.merge!(self.stringify_keys(hash)) }
+    end
+
+    protected
+
+    def stringify_keys(hash)
+      hash.inject({}){|h, (k, v)| h.merge({ k.to_s => v }) }
     end
 
   end

--- a/lib/and-son/connection.rb
+++ b/lib/and-son/connection.rb
@@ -12,7 +12,7 @@ module AndSon
       protocol_connection = Sanford::Protocol::Connection.new(tcp_socket)
       yield protocol_connection if block_given?
     ensure
-      protocol_connection.close rescue false
+      protocol_connection.close
     end
 
     private

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -39,12 +39,13 @@ class AndSon::Client
       assert_equal 10.0, runner.timeout_value
     end
 
-    should "return a CallRunner with params_value set using #params" do
+    should "return a CallRunner with params_value set using #params and stringify " \
+           "the params hash" do
       runner = subject.params({ :api_key => 12345 })
 
       assert_kind_of AndSon::CallRunner, runner
       assert_respond_to :call, runner
-      assert_equal({ :api_key => 12345 }, runner.params_value)
+      assert_equal({ "api_key" => 12345 }, runner.params_value)
     end
 
     should "raise an ArgumentError when #params is not passed a Hash" do


### PR DESCRIPTION
This will keep issues with same named symbol and string keys, which causes
confusion on which one "wins" when the request is sent to the server.

@kellyredding - I didn't do the recursive stringifying here. I don't see it as an issue here because if you pass a nested-hash with mixed keys, that's on you. The goal here was to try to avoid confusion with params chaining:

``` ruby
# care about this case
client = AndSon.new(...).params({ :api_key => 12345 })
# some time later, you go to use the client
client.params({ "api_key" => 54321 }) # previously, this wouldn't overwrite, so it's random which one "wins"

# don't care about this
client.params({ :nested => { :something => true, "something" => false } })
```
