### PR TITLE
Add testing pattern to disable actually calling requests

### DIFF
--- a/lib/and-son/client.rb
+++ b/lib/and-son/client.rb
@@ -2,6 +2,7 @@ require 'ostruct'
 require 'sanford-protocol'
 require 'and-son/connection'
 require 'and-son/response'
+require 'and-son/stored_responses'
 
 module AndSon
 
@@ -31,10 +32,17 @@ module AndSon
 
   end
 
-  class Client < Struct.new(:host, :port, :version)
+  class Client
     include CallRunnerMethods
 
     DEFAULT_TIMEOUT = 60 #seconds
+
+    attr_reader :host, :port, :version, :responses
+
+    def initialize(host, port, version)
+      @host, @port, @version = host, port, version
+      @responses = AndSon::StoredResponses.new
+    end
 
     # proxy the call method to the call runner
     def call(*args, &block); self.call_runner.call(*args, &block); end
@@ -42,35 +50,43 @@ module AndSon
     def call_runner
       # always start with this default CallRunner
       CallRunner.new({
-        :host    => host,
-        :port    => port,
-        :version => version,
+        :host     => host,
+        :port     => port,
+        :version  => version,
         :timeout_value => (ENV['ANDSON_TIMEOUT'] || DEFAULT_TIMEOUT).to_f,
-        :params_value  => {}
+        :params_value  => {},
+        :responses     => @responses,
       })
     end
   end
 
-  class CallRunner < OpenStruct # {:host, :port, :version, :timeout_value, :params_value}
+  class CallRunner < OpenStruct
+    # {:host, :port, :version, :timeout_value, :params_value, :responses}
     include CallRunnerMethods
 
     # chain runner methods by returning itself
     def call_runner; self; end
 
-    def call(name, params = {})
+    def call(name, params = nil)
+      params ||= {}
       if !params.kind_of?(Hash)
-        raise ArgumentError, "expected params to be a Hash instead of a #{hash.class}"
+        raise ArgumentError, "expected params to be a Hash instead of a #{params.class}"
       end
+      client_response = self.responses.find(name, params) if ENV['ANDSON_TEST_MODE']
+      client_response ||= self.call!(name, params)
+
+      if block_given?
+        yield client_response.protocol_response
+      else
+        client_response.data
+      end
+    end
+
+    def call!(name, params)
       call_params = self.params_value.merge(params)
       AndSon::Connection.new(host, port).open do |connection|
         connection.write(Sanford::Protocol::Request.new(version, name, call_params).to_hash)
-        client_response = AndSon::Response.parse(connection.read(timeout_value))
-
-        if block_given?
-          yield client_response.protocol_response
-        else
-          client_response.data
-        end
+        AndSon::Response.parse(connection.read(timeout_value))
       end
     end
 

--- a/lib/and-son/stored_responses.rb
+++ b/lib/and-son/stored_responses.rb
@@ -1,0 +1,33 @@
+require 'sanford-protocol'
+require 'and-son/response'
+
+module AndSon
+
+  class StoredResponses
+
+    RequestData = Struct.new(:name, :params)
+
+    def initialize
+      @hash = {}
+    end
+
+    def add(name, params = nil)
+      request_data = RequestData.new(name, params || {})
+      response = yield
+      if !response.kind_of?(Sanford::Protocol::Response)
+        response = Sanford::Protocol::Response.new(200, response)
+      end
+      @hash[request_data] = AndSon::Response.new(response)
+    end
+
+    def find(name, params = nil)
+      @hash[RequestData.new(name, params || {})]
+    end
+
+    def remove(name, params = nil)
+      @hash.delete(RequestData.new(name, params || {}))
+    end
+
+  end
+
+end

--- a/test/system/making_requests_test.rb
+++ b/test/system/making_requests_test.rb
@@ -29,6 +29,28 @@ class MakingRequestsTest < Assert::Context
 
   end
 
+  class WithStoredResponsesTest < MakingRequestsTest
+    desc "is stored with and-son and with testing ENV var set"
+    setup do
+      ENV['ANDSON_TEST_MODE'] = 'yes'
+    end
+    teardown do
+      ENV.delete('ANDSON_TEST_MODE')
+    end
+
+    should "return the registered response" do
+      client = AndSon.new('localhost', 12000, 'v1')
+      client.responses.add('echo', 'message' => 'test'){ 'test' }
+
+      client.call('echo', 'message' => 'test') do |response|
+        assert_equal 200,     response.code
+        assert_equal nil,     response.status.message
+        assert_equal 'test',  response.data
+      end
+    end
+
+  end
+
   class AuthorizeTest < MakingRequestsTest
     setup do
       @fake_server.add_handler('v1', 'authorize_it') do |params|

--- a/test/unit/stored_responses_test.rb
+++ b/test/unit/stored_responses_test.rb
@@ -1,0 +1,82 @@
+require 'assert'
+
+class AndSon::StoredResponses
+
+  class BaseTest < Assert::Context
+    desc "AndSon::StoredResponses"
+    setup do
+      @responses = AndSon::StoredResponses.new
+    end
+    subject{ @responses }
+
+    should have_instance_methods :add, :remove, :find
+
+  end
+
+  class AddTest < BaseTest
+    desc "add"
+
+    should "allow adding responses given an name and optional params" do
+      subject.add('test', { 'id' => 1 }) do
+        Sanford::Protocol::Response.new([ 404, 'not found' ])
+      end
+      response = subject.find('test', { 'id' => 1 }).protocol_response
+
+      assert_equal 404,         response.code
+      assert_equal 'not found', response.status.message
+      assert_equal nil,         response.data
+
+      subject.add('test'){ Sanford::Protocol::Response.new([ 404, 'not found' ]) }
+      response = subject.find('test').protocol_response
+
+      assert_equal 404,         response.code
+      assert_equal 'not found', response.status.message
+      assert_equal nil,         response.data
+    end
+
+    should "default the response as a 200 when only given response data" do
+      subject.add('test'){ true }
+      response = subject.find('test').protocol_response
+
+      assert_equal 200,   response.code
+      assert_equal nil,   response.status.message
+      assert_equal true,  response.data
+    end
+
+  end
+
+  class FindTest < BaseTest
+    desc "find"
+    setup do
+      @responses.add('test', { 'id' => 1 }){ true }
+      @responses.add('test'){ true }
+    end
+
+    should "allow finding a response given a name and optional params" do
+      response = subject.find('test', { 'id' => 1 }).protocol_response
+      assert_equal true, response.data
+
+      response = subject.find('test').protocol_response
+      assert_equal true, response.data
+    end
+
+  end
+
+  class RemoveTest < BaseTest
+    desc "remove"
+    setup do
+      @responses.add('test', { 'id' => 1 }){ true }
+      @responses.add('test'){ true }
+    end
+
+    should "remove responses given a name and optional params" do
+      subject.remove('test', { 'id' => 1 })
+      assert_nil subject.find('test', { 'id' => 1 })
+
+      subject.remove('test')
+      assert_nil      subject.find('test')
+    end
+
+  end
+
+end


### PR DESCRIPTION
This adds a testing pattern to AndSon where responses to
requests can be configured to prevent AndSon clients from
actually making requests. Instead, it will look at what's
configured and return that. This is only turned on if the
env variable `ANDSON_TESTING` is set. The point of this is
to allow AndSon to be put into a testing mode so that it
can be used without having to start up a server and run
requests against that.
