### PR TITLE
Stop confusing exception when AndSon can't bind to a server

### DIFF
--- a/lib/and-son/connection.rb
+++ b/lib/and-son/connection.rb
@@ -12,7 +12,7 @@ module AndSon
       protocol_connection = Sanford::Protocol::Connection.new(tcp_socket)
       yield protocol_connection if block_given?
     ensure
-      protocol_connection.close
+      protocol_connection.close if protocol_connection
     end
 
     private


### PR DESCRIPTION
Previously, we were getting an `NoMethodError` for `close` on the
connection (because it could never make a connection) when a
client couldn't bind. This fixes that by making sure protocol
connection has been set before trying to close it. With this, you
will get an exception like: `Errno::ECONNREFUSED`, which is
the normal exception for the problem.

Fixes #13
