### PR TITLE
Raise custom "Connection Closed" exception

### DIFF
--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -4,6 +4,8 @@ require 'and-son/stored_responses'
 class AndSon::Client
 
   class BaseTest < Assert::Context
+    include FakeServer::Helper
+
     desc "AndSon::Client"
     setup do
       @host, @port, @version = '0.0.0.0', 8000, "v1"
@@ -74,6 +76,16 @@ class AndSon::Client
 
     should "track its stored responses" do
       assert_kind_of AndSon::StoredResponses, subject.responses
+    end
+
+    should "raise a ConnectionClosedError when the server closes the connection" do
+      self.start_closing_server(12001) do
+        client = AndSon::Client.new('localhost', 12001, 'v1')
+
+        assert_raises(AndSon::ConnectionClosedError) do
+          client.call('anything')
+        end
+      end
     end
 
   end


### PR DESCRIPTION
This is to provide a less confusing exception when the remote
server closes a connection and no response is written. This can
happen when a load balancer is put in front of a Sanford server
and the Sanford server is down. Previously, you would get a
"Protocol version mismatch" error which is confusing and not
actually the problem. This will now say accurately that the
"Connection was closed".

Closes #16
