### PR TITLE
Close the write stream of the socket after writing a request

### DIFF
--- a/lib/and-son/client.rb
+++ b/lib/and-son/client.rb
@@ -107,6 +107,7 @@ module AndSon
       call_params = self.params_value.merge(params)
       AndSon::Connection.new(host, port).open do |connection|
         connection.write(Sanford::Protocol::Request.new(version, name, call_params).to_hash)
+        connection.close_write
         if !connection.peek(timeout_value).empty?
           AndSon::Response.parse(connection.read(timeout_value))
         else

--- a/test/support/fake_connection.rb
+++ b/test/support/fake_connection.rb
@@ -1,0 +1,28 @@
+class FakeConnection
+  attr_reader :written
+
+  def initialize
+    @written = []
+  end
+
+  def peek(*args)
+    "peek_data"
+  end
+
+  def read(*args)
+    { 'status' => [ 200 ], 'data' => {} }
+  end
+
+  def write(request_hash)
+    @written << request_hash
+  end
+
+  def close_write
+    @write_stream_closed = true
+  end
+
+  def write_stream_closed?
+    !!@write_stream_closed
+  end
+
+end


### PR DESCRIPTION
This closes the write stream of the socket after writing a
request. The benefit is notifying the server that we are done
writing the request and that it can begin reading and handling
our response. The server/socket usually figures this out, but
closing this is more reliable.
