### PR TITLE
Remove calling services with a version

### DIFF
--- a/and-son.gemspec
+++ b/and-son.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency("sanford-protocol",  ["~>0.5"])
+  gem.add_dependency("sanford-protocol",  ["~>0.6"])
 
-  gem.add_development_dependency("assert",        ["~>2.0"])
+  gem.add_development_dependency("assert",        ["~>2.3"])
   gem.add_development_dependency("assert-mocha",  ["~>1.0"])
 end

--- a/test/support/fake_server.rb
+++ b/test/support/fake_server.rb
@@ -11,8 +11,8 @@ class FakeServer
     @slow = !!options[:slow]
   end
 
-  def add_handler(version, name, &block)
-    @handlers["#{version}-#{name}"] = block
+  def add_handler(name, &block)
+    @handlers[name] = block
   end
 
   def run
@@ -44,7 +44,7 @@ class FakeServer
   end
 
   def route(request)
-    handler = @handlers["#{request.version}-#{request.name}"]
+    handler = @handlers[request.name]
     returned = handler.call(request.params)
   end
 

--- a/test/system/making_requests_tests.rb
+++ b/test/system/making_requests_tests.rb
@@ -13,13 +13,13 @@ class MakingRequestsTests < Assert::Context
   class SuccessTests < MakingRequestsTests
     desc "returns a successful response"
     setup do
-      @fake_server.add_handler('v1', 'echo'){|params| [ 200, params['message'] ] }
+      @fake_server.add_handler('echo'){|params| [ 200, params['message'] ] }
     end
 
     should "get a 200 response with the parameter echoed back" do
       self.run_fake_server(@fake_server) do
 
-        client = AndSon.new('localhost', 12000, 'v1')
+        client = AndSon.new('localhost', 12000)
         client.call('echo', :message => 'test') do |response|
           assert_equal 200,     response.status.code
           assert_equal nil,     response.status.message
@@ -41,7 +41,7 @@ class MakingRequestsTests < Assert::Context
     end
 
     should "return the registered response" do
-      client = AndSon.new('localhost', 12000, 'v1')
+      client = AndSon.new('localhost', 12000)
       client.responses.add('echo', 'message' => 'test'){ 'test' }
 
       client.call('echo', 'message' => 'test') do |response|
@@ -55,7 +55,7 @@ class MakingRequestsTests < Assert::Context
 
   class AuthorizeTests < MakingRequestsTests
     setup do
-      @fake_server.add_handler('v1', 'authorize_it') do |params|
+      @fake_server.add_handler('authorize_it') do |params|
         if params['api_key'] == 12345
           [ 200, params['data'] ]
         else
@@ -67,7 +67,7 @@ class MakingRequestsTests < Assert::Context
     should "get a 200 response when api_key is passed with the correct value" do
       self.run_fake_server(@fake_server) do
 
-        client = AndSon.new('localhost', 12000, 'v1').params({ 'api_key' => 12345 })
+        client = AndSon.new('localhost', 12000).params({ 'api_key' => 12345 })
         client.call('authorize_it', { 'data' => 'holla' }) do |response|
           assert_equal 200,     response.status.code
           assert_equal nil,     response.status.message
@@ -80,7 +80,7 @@ class MakingRequestsTests < Assert::Context
     should "get a 401 response when api_key isn't passed" do
       self.run_fake_server(@fake_server) do
 
-        client = AndSon.new('localhost', 12000, 'v1')
+        client = AndSon.new('localhost', 12000)
         client.call('authorize_it', { 'data' => 'holla' }) do |response|
           assert_equal 401,     response.status.code
           assert_equal nil,     response.status.message
@@ -95,14 +95,14 @@ class MakingRequestsTests < Assert::Context
   class Failure400Tests < MakingRequestsTests
     desc "when a request fails with a 400"
     setup do
-      @fake_server.add_handler('v1', '400'){|params| [ 400, false ] }
+      @fake_server.add_handler('400'){|params| [ 400, false ] }
     end
 
     should "raise a bad request error" do
       self.run_fake_server(@fake_server) do
 
         assert_raises(AndSon::BadRequestError) do
-          client = AndSon.new('localhost', 12000, 'v1')
+          client = AndSon.new('localhost', 12000)
           client.call('400')
         end
 
@@ -114,14 +114,14 @@ class MakingRequestsTests < Assert::Context
   class Failure404Tests < MakingRequestsTests
     desc "when a request fails with a 404"
     setup do
-      @fake_server.add_handler('v1', '404'){|params| [ 404, false ] }
+      @fake_server.add_handler('404'){|params| [ 404, false ] }
     end
 
     should "raise a not found error" do
       self.run_fake_server(@fake_server) do
 
         assert_raises(AndSon::NotFoundError) do
-          client = AndSon.new('localhost', 12000, 'v1')
+          client = AndSon.new('localhost', 12000)
           client.call('404')
         end
 
@@ -133,14 +133,14 @@ class MakingRequestsTests < Assert::Context
   class Failure4xxTests < MakingRequestsTests
     desc "when a request fails with a 4xx"
     setup do
-      @fake_server.add_handler('v1', '4xx'){|params| [ 402, false ] }
+      @fake_server.add_handler('4xx'){|params| [ 402, false ] }
     end
 
     should "raise a client error" do
       self.run_fake_server(@fake_server) do
 
         assert_raises(AndSon::ClientError) do
-          client = AndSon.new('localhost', 12000, 'v1')
+          client = AndSon.new('localhost', 12000)
           client.call('4xx')
         end
 
@@ -152,14 +152,14 @@ class MakingRequestsTests < Assert::Context
   class Failure5xxTests < MakingRequestsTests
     desc "when a request fails with a 5xx"
     setup do
-      @fake_server.add_handler('v1', '5xx'){|params| [ 500, false ] }
+      @fake_server.add_handler('5xx'){|params| [ 500, false ] }
     end
 
     should "raise a server error" do
       self.run_fake_server(@fake_server) do
 
         assert_raises(AndSon::ServerError) do
-          client = AndSon.new('localhost', 12000, 'v1')
+          client = AndSon.new('localhost', 12000)
           client.call('5xx')
         end
 
@@ -171,7 +171,7 @@ class MakingRequestsTests < Assert::Context
   class TimeoutErrorTests < MakingRequestsTests
     desc "when a request takes to long to respond"
     setup do
-      @fake_server.add_handler('v1', 'forever') do |params|
+      @fake_server.add_handler('forever') do |params|
         sleep 0.2
         [ 200, true ]
       end
@@ -181,7 +181,7 @@ class MakingRequestsTests < Assert::Context
       self.run_fake_server(@fake_server) do
 
         assert_raises(Sanford::Protocol::TimeoutError) do
-          client = AndSon.new('localhost', 12000, 'v1')
+          client = AndSon.new('localhost', 12000)
           client.timeout(0.1).call('forever')
         end
 

--- a/test/unit/client_tests.rb
+++ b/test/unit/client_tests.rb
@@ -11,12 +11,12 @@ class AndSon::Client
 
     desc "AndSon::Client"
     setup do
-      @host, @port, @version = '0.0.0.0', 8000, "v1"
-      @client = AndSon::Client.new(@host, @port, @version)
+      @host, @port = '0.0.0.0', 8000
+      @client = AndSon::Client.new(@host, @port)
     end
     subject{ @client }
 
-    should have_imeths :host, :port, :version, :responses
+    should have_imeths :host, :port, :responses
     should have_imeths :call_runner, :call, :timeout, :logger, :params
 
     should "know its default call runner" do
@@ -24,7 +24,6 @@ class AndSon::Client
 
       assert_equal @host, default_runner.host
       assert_equal @port, default_runner.port
-      assert_equal @version, default_runner.version
       assert_equal 60.0, default_runner.timeout_value
       assert_instance_of AndSon::NullLogger, default_runner.logger_value
     end
@@ -89,12 +88,11 @@ class AndSon::Client
     should "write a request to the connection" do
       @connection.stubs(:open).yields(@fake_connection).returns(@response)
 
-      client = AndSon::Client.new('localhost', 12001, 'v1').call('echo', {
+      client = AndSon::Client.new('localhost', 12001).call('echo', {
         :message => 'test'
       })
 
       request_data = @fake_connection.written.first
-      assert_equal 'v1',                    request_data['version']
       assert_equal 'echo',                  request_data['name']
       assert_equal({ 'message' => 'test' }, request_data['params'])
     end
@@ -102,7 +100,7 @@ class AndSon::Client
     should "close the write stream" do
       @connection.stubs(:open).yields(@fake_connection).returns(@response)
 
-      client = AndSon::Client.new('localhost', 12001, 'v1').call('echo', {
+      client = AndSon::Client.new('localhost', 12001).call('echo', {
         :message => 'test'
       })
 
@@ -110,7 +108,7 @@ class AndSon::Client
     end
 
     should "raise an ArgumentError when #call is not passed a Hash for params" do
-      client = AndSon::Client.new('localhost', 12001, 'v1')
+      client = AndSon::Client.new('localhost', 12001)
       runner = client.timeout(0.1) # in case it actually tries to make the request
 
       assert_raises(ArgumentError) do
@@ -120,7 +118,7 @@ class AndSon::Client
 
     should "raise a ConnectionClosedError when the server closes the connection" do
       self.start_closing_server(12001) do
-        client = AndSon::Client.new('localhost', 12001, 'v1')
+        client = AndSon::Client.new('localhost', 12001)
 
         assert_raises(AndSon::ConnectionClosedError) do
           client.call('anything')


### PR DESCRIPTION
This removes calling services with a version. Services are no
longer added with a version in Sanford and the protocol no longer
supports passing a version. If "versioned" services are wanted,
the version identifier should be added to the service's name.
This is more flexible and makes it more clear that services can
be versioned independently.
