### PR TITLE
Update stored responses to call block when the service is called

### DIFF
--- a/and-son.gemspec
+++ b/and-son.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency("sanford-protocol",  ["~>0.6"])
 
-  gem.add_development_dependency("assert",        ["~>2.3"])
+  gem.add_development_dependency("assert",        ["~>2.9"])
   gem.add_development_dependency("assert-mocha",  ["~>1.0"])
 end

--- a/lib/and-son/stored_responses.rb
+++ b/lib/and-son/stored_responses.rb
@@ -11,17 +11,19 @@ module AndSon
       @hash = {}
     end
 
-    def add(name, params = nil)
+    def add(name, params = nil, &response_block)
       request_data = RequestData.new(name, params || {})
-      response = yield
-      if !response.kind_of?(Sanford::Protocol::Response)
-        response = Sanford::Protocol::Response.new(200, response)
-      end
-      @hash[request_data] = AndSon::Response.new(response)
+      @hash[request_data] = response_block
     end
 
     def find(name, params = nil)
-      @hash[RequestData.new(name, params || {})]
+      response_block = @hash[RequestData.new(name, params || {})]
+      return if !response_block
+      response = response_block.call
+      if !response.kind_of?(Sanford::Protocol::Response)
+        response = Sanford::Protocol::Response.new(200, response)
+      end
+      AndSon::Response.new(response)
     end
 
     def remove(name, params = nil)

--- a/test/unit/and-son_tests.rb
+++ b/test/unit/and-son_tests.rb
@@ -3,7 +3,7 @@ require 'and-son'
 
 module AndSon
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "AndSon"
     subject{ AndSon }
 

--- a/test/unit/client_tests.rb
+++ b/test/unit/client_tests.rb
@@ -6,7 +6,7 @@ require 'and-son/client'
 
 class AndSon::Client
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     include FakeServer::Helper
 
     desc "AndSon::Client"
@@ -73,7 +73,7 @@ class AndSon::Client
 
   end
 
-  class CallTest < BaseTests
+  class CallTest < UnitTests
     desc "call"
     setup do
       @connection = AndSon::Connection.new('localhost', 12001)

--- a/test/unit/response_tests.rb
+++ b/test/unit/response_tests.rb
@@ -3,7 +3,7 @@ require 'and-son/response'
 
 class AndSon::Response
 
-  class BaseTests < Assert::Context
+  class UnitTests < Assert::Context
     desc "AndSon::Response"
     setup do
       @protocol_response = Sanford::Protocol::Response.new([ 200, 'message' ], 'data')
@@ -26,7 +26,7 @@ class AndSon::Response
 
   end
 
-  class FailedResponseTests < BaseTests
+  class FailedResponseTests < UnitTests
     desc "given a failed response"
     setup do
       @protocol_response = Sanford::Protocol::Response.new([ 500, 'message' ])
@@ -45,7 +45,7 @@ class AndSon::Response
 
   end
 
-  class Response5xxTests < BaseTests
+  class Response5xxTests < UnitTests
     desc "given a 5xx response"
     setup do
       @protocol_response = Sanford::Protocol::Response.new(500)
@@ -61,7 +61,7 @@ class AndSon::Response
 
   end
 
-  class Response404Tests < BaseTests
+  class Response404Tests < UnitTests
     desc "given a 404 response"
     setup do
       @protocol_response = Sanford::Protocol::Response.new(404)
@@ -78,7 +78,7 @@ class AndSon::Response
 
   end
 
-  class Response400Tests < BaseTests
+  class Response400Tests < UnitTests
     desc "given a 400 response"
     setup do
       @protocol_response = Sanford::Protocol::Response.new(400)
@@ -95,7 +95,7 @@ class AndSon::Response
 
   end
 
-  class Response4xxTests < BaseTests
+  class Response4xxTests < UnitTests
     desc "given a 4xx response"
     setup do
       @protocol_response = Sanford::Protocol::Response.new(402)

--- a/test/unit/stored_responses_tests.rb
+++ b/test/unit/stored_responses_tests.rb
@@ -3,7 +3,7 @@ require 'and-son/stored_responses'
 
 class AndSon::StoredResponses
 
-  class BaseTest < Assert::Context
+  class UnitTests < Assert::Context
     desc "AndSon::StoredResponses"
     setup do
       @responses = AndSon::StoredResponses.new
@@ -14,7 +14,7 @@ class AndSon::StoredResponses
 
   end
 
-  class AddTest < BaseTest
+  class AddTest < UnitTests
     desc "add"
 
     should "allow adding responses given an name and optional params" do
@@ -46,11 +46,13 @@ class AndSon::StoredResponses
 
   end
 
-  class FindTest < BaseTest
+  class FindTest < UnitTests
     desc "find"
     setup do
       @responses.add('test', { 'id' => 1 }){ true }
       @responses.add('test'){ true }
+      @service_called = false
+      @responses.add('call_service'){ @service_called = true }
     end
 
     should "allow finding a response given a name and optional params" do
@@ -61,9 +63,15 @@ class AndSon::StoredResponses
       assert_equal true, response.data
     end
 
+    should "not call the response block until `find` is called" do
+      assert_false @service_called
+      subject.find('call_service')
+      assert_true @service_called
+    end
+
   end
 
-  class RemoveTest < BaseTest
+  class RemoveTest < UnitTests
     desc "remove"
     setup do
       @responses.add('test', { 'id' => 1 }){ true }


### PR DESCRIPTION
This updates the stored responses to delay calling the response
block till when the service is called. This allows testing that
a service is or isn't called by a piece of code. Previously, the
block would be called when the stored response was added. This
meant that it couldn't easily be tested if a service was called
or not. The response of the service needed to be saved off in the
thing calling it and then that should be checked to make sure it
was set or not. Now, a flag can be set in the respone block and
then a test can ensure it is set or not.

This also cleans up the test suite from using the name `BaseTests`
to `UnitTests`. This is a more clear and expressive naming.

@kellyredding - Ready for review. This is needed for some testing I'm doing. I essentially want to do:

``` ruby
client = AndSon.new(...)
service_called = false
client.responses.add('my_service', { ... }){ service_called = true }
assert_false service_called
client.call('my_service', { ... })
assert_true service_called
```

I don't care what the response is, I only want to ensure that a set of code runs the service I expect.
