### PR TITLE
update to the latest assert; new stubbing api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rake'
-gem 'pry'
+gem 'pry', "~> 0.9.0"
 
 gem 'bson_ext'

--- a/and-son.gemspec
+++ b/and-son.gemspec
@@ -20,6 +20,5 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency("sanford-protocol",  ["~> 0.8"])
 
-  gem.add_development_dependency("assert",        ["~> 2.10"])
-  gem.add_development_dependency("assert-mocha",  ["~> 1.1"])
+  gem.add_development_dependency("assert", ["~> 2.11"])
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -6,4 +6,3 @@ $LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
 
 # require pry for debugging (`binding.pry`)
 require 'pry'
-require 'assert-mocha' if defined?(Assert)

--- a/test/unit/client_tests.rb
+++ b/test/unit/client_tests.rb
@@ -80,14 +80,14 @@ class AndSon::Client
       @connection = AndSon::Connection.new('localhost', 12001)
       @response = AndSon::Response.parse({ 'status' => [200] })
       @fake_connection = FakeConnection.new
-      AndSon::Connection.stubs(:new).returns(@connection)
-    end
-    teardown do
-      AndSon::Connection.unstub(:new)
+      Assert.stub(AndSon::Connection, :new){ @connection }
     end
 
     should "write a request to the connection" do
-      @connection.stubs(:open).yields(@fake_connection).returns(@response)
+      Assert.stub(@connection, :open) do |&block|
+        block.call(@fake_connection)
+        @response
+      end
 
       client = AndSon::Client.new('localhost', 12001).call('echo', {
         :message => 'test'
@@ -99,7 +99,10 @@ class AndSon::Client
     end
 
     should "close the write stream" do
-      @connection.stubs(:open).yields(@fake_connection).returns(@response)
+      Assert.stub(@connection, :open) do |&block|
+        block.call(@fake_connection)
+        @response
+      end
 
       client = AndSon::Client.new('localhost', 12001).call('echo', {
         :message => 'test'


### PR DESCRIPTION
The latest assert adds its own native stubbing API. The switches
to that. No behavior changes.

@jcredding ready for review.
