### PR TITLE
Add `TestClient`, return default response if one isn't configured

### DIFF
--- a/lib/and-son/call_runner.rb
+++ b/lib/and-son/call_runner.rb
@@ -10,16 +10,15 @@ module AndSon
 
     DEFAULT_TIMEOUT = 60 # seconds
 
-    attr_reader :host, :port, :responses
+    attr_reader :host, :port
     attr_accessor :timeout_value, :params_value, :logger_value
 
-    def initialize(host, port, responses)
+    def initialize(host, port)
       @host = host
       @port = port
       @params_value = {}
       @timeout_value = (ENV['ANDSON_TIMEOUT'] || DEFAULT_TIMEOUT).to_f
       @logger_value = NullLogger.new
-      @responses = responses
     end
 
     # chain runner methods by returning itself
@@ -32,8 +31,7 @@ module AndSon
       end
       client_response = nil
       benchmark = Benchmark.measure do
-        client_response = self.responses.find(name, params) if ENV['ANDSON_TEST_MODE']
-        client_response ||= self.call!(name, params)
+        client_response = self.call!(name, params)
       end
 
       summary_line = SummaryLine.new({

--- a/lib/and-son/stored_responses.rb
+++ b/lib/and-son/stored_responses.rb
@@ -8,7 +8,7 @@ module AndSon
     RequestData = Struct.new(:name, :params)
 
     def initialize
-      @hash = {}
+      @hash = Hash.new{ default_response_proc }
     end
 
     def add(name, params = nil, &response_block)
@@ -16,9 +16,8 @@ module AndSon
       @hash[request_data] = response_block
     end
 
-    def find(name, params = nil)
+    def get(name, params = nil)
       response_block = @hash[RequestData.new(name, params || {})]
-      return if !response_block
       response = response_block.call
       if !response.kind_of?(Sanford::Protocol::Response)
         response = Sanford::Protocol::Response.new(200, response)
@@ -28,6 +27,12 @@ module AndSon
 
     def remove(name, params = nil)
       @hash.delete(RequestData.new(name, params || {}))
+    end
+
+    private
+
+    def default_response_proc
+      proc{ Sanford::Protocol::Response.new(200, {}) }
     end
 
   end

--- a/test/unit/call_runner_tests.rb
+++ b/test/unit/call_runner_tests.rb
@@ -10,7 +10,6 @@ class AndSon::CallRunner
     setup do
       @host = Factory.string
       @port = Factory.integer
-      @responses = AndSon::StoredResponses.new
 
       @call_runner_class = AndSon::CallRunner
     end
@@ -25,18 +24,17 @@ class AndSon::CallRunner
   class InitTests < UnitTests
     desc "when init"
     setup do
-      @call_runner = @call_runner_class.new(@host, @port, @responses)
+      @call_runner = @call_runner_class.new(@host, @port)
     end
     subject{ @call_runner }
 
-    should have_readers :host, :port, :responses
+    should have_readers :host, :port
     should have_accessors :params_value, :timeout_value, :logger_value
     should have_imeths :call_runner
 
-    should "know its host, port and responses" do
+    should "know its host and port" do
       assert_equal @host, subject.host
       assert_equal @port, subject.port
-      assert_equal @responses, subject.responses
     end
 
     should "default its params, timeout and logger" do
@@ -57,7 +55,7 @@ class AndSon::CallRunner
       @current_timeout = ENV['ANDSON_TIMEOUT']
       ENV['ANDSON_TIMEOUT'] = Factory.integer.to_s
 
-      @call_runner = @call_runner_class.new(@host, @port, @responses)
+      @call_runner = @call_runner_class.new(@host, @port)
     end
     teardown do
       ENV['ANDSON_TIMEOUT'] = @current_timeout
@@ -181,39 +179,8 @@ class AndSon::CallRunner
       assert_match regex, @logger_spy.output
     end
 
-    should "not use stored responses even if they are configured" do
-      response_data = Factory.string
-      subject.responses.add(@name, @params){ response_data }
-      assert_not_equal response_data, subject.call(@name, @params)
-    end
-
     should "raise an argument error when not passed a hash for params" do
       assert_raises(ArgumentError){ subject.call(@name, Factory.string) }
-    end
-
-  end
-
-  class CallInTestModeTests < CallSetupTests
-    desc "call method in test mode"
-    setup do
-      @current_timeout = ENV['ANDSON_TEST_MODE']
-      ENV['ANDSON_TEST_MODE'] = 'yes'
-
-      Assert.stub(@call_runner, :call!){ |name, params| @response }
-    end
-    teardown do
-      ENV['ANDSON_TEST_MODE'] = @current_timeout
-    end
-
-    should "use a stored response when they are configured" do
-      response_data = Factory.string
-      subject.responses.add(@name, @params){ response_data }
-      assert_equal response_data, subject.call(@name, @params)
-    end
-
-    should "call `call!` when a stored response isn't configured" do
-      result = subject.call(@name, @params)
-      assert_equal @response.data, result
     end
 
   end


### PR DESCRIPTION
This adds a `TestClient` that is now returned when `Client.new`
is called in test mode. The `TestClient` has the same interface
as a regular client, but never will make an actual TCP request.
It uses the stored responses logic to allow configuring responses.
This allows the `AndSonClient` to not need stored responses and
removes the check for test mode in the `CallRunner.call` method.
This also changes the stored responses to always return a response,
even if one isn't configured. This allows the `TestClient` to
always provide response data. Tests that don't care what the
response is, can now just use the default response. This is also
setup for adding more test features to `TestClient` and stored
responses for better usability.

Related to #31 

@kellyredding - Ready for review.
