### PR TITLE
Update `TestClient`, track all calls made with it

### DIFF
--- a/lib/and-son/client.rb
+++ b/lib/and-son/client.rb
@@ -47,16 +47,18 @@ module AndSon
   class TestClient
     include Client
 
-    attr_reader :responses
+    attr_reader :calls, :responses
 
     def initialize(host, port)
       super
+      @calls = []
       @responses = AndSon::StoredResponses.new
     end
 
     def call(name, params = nil)
       params ||= {}
       response = self.responses.get(name, params)
+      self.calls << Call.new(name, params, response.protocol_response)
       if block_given?
         yield response.protocol_response
       else
@@ -65,6 +67,14 @@ module AndSon
     end
 
     def call_runner; self; end
+
+    def reset
+      self.calls.clear
+      self.responses.remove_all
+    end
+
+    Call = Struct.new(:request_name, :request_params, :response)
+
   end
 
 end

--- a/lib/and-son/stored_responses.rb
+++ b/lib/and-son/stored_responses.rb
@@ -29,6 +29,10 @@ module AndSon
       @hash.delete(RequestData.new(name, params || {}))
     end
 
+    def remove_all
+      @hash.clear
+    end
+
     private
 
     def default_response_proc

--- a/test/unit/stored_responses_tests.rb
+++ b/test/unit/stored_responses_tests.rb
@@ -6,11 +6,30 @@ class AndSon::StoredResponses
   class UnitTests < Assert::Context
     desc "AndSon::StoredResponses"
     setup do
+      @name = Factory.string
+      @params = { Factory.string => Factory.string }
+
+      @protocol_response = Sanford::Protocol::Response.new(
+        [ Factory.integer, Factory.string ],
+        Factory.string
+      )
+
       @responses = AndSon::StoredResponses.new
     end
     subject{ @responses }
 
-    should have_imeths :add, :remove, :get
+    should have_imeths :add, :remove, :get, :remove_all
+
+    should "allow removing all responses" do
+      subject.add(@name, @params){ @protocol_response }
+      subject.add(@name){ @protocol_response }
+
+      subject.remove_all
+      protocol_response = subject.get(@name, @params).protocol_response
+      assert_not_equal @protocol_response, protocol_response
+      protocol_response = subject.get(@name).protocol_response
+      assert_not_equal @protocol_response, protocol_response
+    end
 
   end
 


### PR DESCRIPTION
This updates `TestClient` to track all calls that it makes. This
is so it can act as a spy and users can check that a call was made
with the expected name and params. This also updates the
`TestClient` to have a `reset` method that will clear its calls
and remove all of its configured stored responses. This is so
this one method can be called in a test teardown. This makes it
easier if a client is re-used instead of having to manually clear
the calls and keep up with all the configured responses.

Closes #31

@kellyredding - Ready for review.
