### PR TITLE
Allow more flexible adding of stored responses

### DIFF
--- a/and-son.gemspec
+++ b/and-son.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency("sanford-protocol",  ["~> 0.9"])
+  gem.add_dependency("sanford-protocol",  ["~> 0.10"])
 
   gem.add_development_dependency("assert", ["~> 2.12"])
 end

--- a/lib/and-son/stored_responses.rb
+++ b/lib/and-son/stored_responses.rb
@@ -18,10 +18,7 @@ module AndSon
 
     def get(name, params = nil)
       response_block = @hash[RequestData.new(name, params || {})]
-      response = response_block.call
-      if !response.kind_of?(Sanford::Protocol::Response)
-        response = Sanford::Protocol::Response.new(200, response)
-      end
+      response = handle_response_block(response_block)
       AndSon::Response.new(response)
     end
 
@@ -35,8 +32,20 @@ module AndSon
 
     private
 
+    def handle_response_block(response_block)
+      if response_block.arity == 0 || response_block.arity == -1
+        default_response.tap{ |r| r.data = response_block.call }
+      else
+        default_response.tap{ |r| response_block.call(r) }
+      end
+    end
+
+    def default_response
+      Sanford::Protocol::Response.new(200, {})
+    end
+
     def default_response_proc
-      proc{ Sanford::Protocol::Response.new(200, {}) }
+      proc{ |r| r.data = Hash.new }
     end
 
   end

--- a/test/unit/stored_responses_tests.rb
+++ b/test/unit/stored_responses_tests.rb
@@ -8,117 +8,93 @@ class AndSon::StoredResponses
     setup do
       @name = Factory.string
       @params = { Factory.string => Factory.string }
-
-      @protocol_response = Sanford::Protocol::Response.new(
-        [ Factory.integer, Factory.string ],
-        Factory.string
-      )
+      @response_data = Factory.string
 
       @responses = AndSon::StoredResponses.new
     end
     subject{ @responses }
 
-    should have_imeths :add, :remove, :get, :remove_all
+    should have_imeths :add, :get, :remove, :remove_all
 
-    should "allow removing all responses" do
-      subject.add(@name, @params){ @protocol_response }
-      subject.add(@name){ @protocol_response }
-
-      subject.remove_all
+    should "allow adding and getting responses with response data" do
+      subject.add(@name, @params){ @response_data }
       protocol_response = subject.get(@name, @params).protocol_response
-      assert_not_equal @protocol_response, protocol_response
-      protocol_response = subject.get(@name).protocol_response
-      assert_not_equal @protocol_response, protocol_response
+      assert_equal 200, protocol_response.code
+      assert_nil protocol_response.status.message
+      assert_equal @response_data, protocol_response.data
     end
 
-  end
+    should "allow adding and gettings responses being yielded a response" do
+      code = Factory.integer
+      message = Factory.string
+      data = Factory.string
 
-  class AddTest < UnitTests
-    desc "add"
-
-    should "allow adding responses given an name and optional params" do
-      subject.add('test', { 'id' => 1 }) do
-        Sanford::Protocol::Response.new([ 404, 'not found' ])
+      yielded = nil
+      subject.add(@name, @params) do |response|
+        yielded = response
+        response.code = code
+        response.message = message
+        response.data = data
       end
-      response = subject.get('test', { 'id' => 1 }).protocol_response
+      protocol_response = subject.get(@name, @params).protocol_response
 
-      assert_equal 404,         response.code
-      assert_equal 'not found', response.status.message
-      assert_equal nil,         response.data
-
-      subject.add('test'){ Sanford::Protocol::Response.new([ 404, 'not found' ]) }
-      response = subject.get('test').protocol_response
-
-      assert_equal 404,         response.code
-      assert_equal 'not found', response.status.message
-      assert_equal nil,         response.data
+      assert_instance_of Sanford::Protocol::Response, yielded
+      assert_equal code, protocol_response.code
+      assert_equal message, protocol_response.message
+      assert_equal data, protocol_response.data
     end
 
-    should "default the response as a 200 when only given response data" do
-      subject.add('test'){ true }
-      response = subject.get('test').protocol_response
-
-      assert_equal 200,  response.code
-      assert_equal nil,  response.status.message
-      assert_equal true, response.data
+    should "allow adding and getting responses with no params" do
+      subject.add(@name){ @response_data }
+      protocol_response = subject.get(@name).protocol_response
+      assert_equal @response_data, protocol_response.data
     end
 
-  end
-
-  class GetTest < UnitTests
-    desc "get"
-    setup do
-      @responses.add('test', { 'id' => 1 }){ true }
-      @responses.add('test'){ true }
-      @service_called = false
-      @responses.add('call_service'){ @service_called = true }
-    end
-
-    should "return a default response with a name/params that aren't configured" do
-      response = subject.get(Factory.string, { Factory.string => Factory.string })
+    should "return a default response for a name/params that isn't configured" do
+      response = subject.get(@name, @params)
       protocol_response = response.protocol_response
       assert_equal 200, protocol_response.code
       assert_nil protocol_response.status.message
       assert_equal({}, protocol_response.data)
     end
 
-    should "allow geting a response given a name and optional params" do
-      response = subject.get('test', { 'id' => 1 }).protocol_response
-      assert_equal true, response.data
-
-      response = subject.get('test').protocol_response
-      assert_equal true, response.data
+    should "not call a response block until it is retrieved" do
+      called = false
+      subject.add(@name){ called = true }
+      assert_false called
+      subject.get(@name)
+      assert_true called
     end
 
-    should "not call the response block until `get` is called" do
-      assert_false @service_called
-      subject.get('call_service')
-      assert_true @service_called
+    should "allow removing a response" do
+      subject.add(@name, @params){ @response_data }
+      protocol_response = subject.get(@name, @params).protocol_response
+      assert_equal @response_data, protocol_response.data
+
+      subject.remove(@name, @params)
+      protocol_response = subject.get(@name, @params).protocol_response
+      assert_not_equal @response_data, protocol_response.data
     end
 
-  end
+    should "allow removing a response without params" do
+      subject.add(@name){ @response_data }
+      protocol_response = subject.get(@name).protocol_response
+      assert_equal @response_data, protocol_response.data
 
-  class RemoveTest < UnitTests
-    desc "remove"
-    setup do
-      @responses.add('test', { 'id' => 1 }){ true }
-      @responses.add('test'){ true }
+      subject.remove(@name)
+      protocol_response = subject.get(@name).protocol_response
+      assert_not_equal @response_data, protocol_response.data
     end
 
-    should "remove responses given a name and optional params" do
-      response = subject.get('test', { 'id' => 1 })
-      assert_equal true, response.data
+    should "allow removing all responses" do
+      subject.add(@name, @params){ @response_data }
+      subject.add(@name){ @response_data }
 
-      subject.remove('test', { 'id' => 1 })
-      response = subject.get('test', { 'id' => 1 })
-      assert_not_equal true, response.data
-
-      response = subject.get('test')
-      assert_equal true, response.data
-
-      subject.remove('test')
-      response = subject.get('test')
-      assert_not_equal true, response.data
+      subject.remove_all
+      protocol_response = subject.get(@name, @params).protocol_response
+      assert_not_equal @response_data, protocol_response.data
+      protocol_response = subject.get(@name).protocol_response
+      assert_not_equal @response_data, protocol_response.data
     end
 
   end


### PR DESCRIPTION
This updates stored responses to allow adding complex responses
in a simpler manner. If the block that is used with `add` expects
an argument, a response will be yielded to it. This response can
have its code, message or data changed in the block and will be
used as the response. This will allow users to not have to manually
build a protocol response. If an argument is not expected, then the
block will work as it previously did.

Closes #30

@kellyredding - Ready for review.
