### PR TITLE
Demeter adding and removing responses for `TestClient`

### DIFF
--- a/lib/and-son/client.rb
+++ b/lib/and-son/client.rb
@@ -68,6 +68,14 @@ module AndSon
 
     def call_runner; self; end
 
+    def add_response(*args, &block)
+      self.responses.add(*args, &block)
+    end
+
+    def remove_response(*args)
+      self.responses.remove(*args)
+    end
+
     def reset
       self.calls.clear
       self.responses.remove_all

--- a/test/system/making_requests_tests.rb
+++ b/test/system/making_requests_tests.rb
@@ -43,7 +43,7 @@ class MakingRequestsTests < Assert::Context
 
     should "return the registered response" do
       client = AndSon.new('localhost', 12000)
-      client.responses.add('echo', 'message' => 'test'){ 'test' }
+      client.add_response('echo', 'message' => 'test'){ 'test' }
 
       client.call('echo', 'message' => 'test') do |response|
         assert_equal 200,     response.code

--- a/test/unit/client_tests.rb
+++ b/test/unit/client_tests.rb
@@ -111,13 +111,13 @@ module AndSon::Client
 
       @client = AndSon::TestClient.new(@host, @port)
       data = Factory.string
-      @client.responses.add(@name, @params){ data }
+      @client.add_response(@name, @params){ data }
       @response = @client.responses.get(@name, @params)
     end
     subject{ @client }
 
     should have_readers :calls, :responses
-    should have_imeths :reset
+    should have_imeths :add_response, :remove_response, :reset
 
     should "know its stored responses" do
       assert_instance_of AndSon::StoredResponses, subject.responses
@@ -147,6 +147,17 @@ module AndSon::Client
       yielded = nil
       subject.call(@name, @params){ |response| yielded = response }
       assert_equal @response.protocol_response, yielded
+    end
+
+    should "allow adding/removing stored responses" do
+      data = Factory.string
+      subject.add_response(@name, @params){ data }
+      response = subject.responses.get(@name, @params)
+      assert_equal data, response.data
+
+      subject.remove_response(@name, @params)
+      response = subject.responses.get(@name, @params)
+      assert_not_equal data, response.data
     end
 
     should "clear its calls and remove all its configured responses using `reset`" do


### PR DESCRIPTION
This demeters adding and removing responses for `TestClient`s.
This avoids demeter violations that were commonly used like
`client.responses.add`. This is to avoid issues if we decide to
change how the responses are accessed or other parts of their
interface.

@kellyredding - Ready for review.
