### PR TITLE
Allow adding a response for a service for any params

### DIFF
--- a/lib/and-son/client.rb
+++ b/lib/and-son/client.rb
@@ -79,12 +79,12 @@ module AndSon
 
     def call_runner; self; end
 
-    def add_response(*args, &block)
-      self.responses.add(*args, &block)
+    def add_response(name, &block)
+      self.responses.add(name, &block)
     end
 
-    def remove_response(*args)
-      self.responses.remove(*args)
+    def remove_responses(name)
+      self.responses.remove(name)
     end
 
     def reset

--- a/test/unit/stored_responses_tests.rb
+++ b/test/unit/stored_responses_tests.rb
@@ -17,42 +17,50 @@ class AndSon::StoredResponses
     should have_imeths :add, :get, :remove, :remove_all
 
     should "allow adding and getting responses with response data" do
-      subject.add(@name, @params){ @response_data }
-      protocol_response = subject.get(@name, @params).protocol_response
+      subject.add(@name){ @response_data }
+      protocol_response = subject.get(@name, {}).protocol_response
+
       assert_equal 200, protocol_response.code
       assert_nil protocol_response.status.message
       assert_equal @response_data, protocol_response.data
     end
 
-    should "allow adding and gettings responses being yielded a response" do
-      code = Factory.integer
+    should "allow adding and getting responses when yielded a response" do
+      code    = Factory.integer
       message = Factory.string
-      data = Factory.string
+      data    = Factory.string
 
       yielded = nil
-      subject.add(@name, @params) do |response|
+      subject.add(@name) do |response|
         yielded = response
-        response.code = code
+        response.code    = code
         response.message = message
-        response.data = data
+        response.data    = data
       end
-      protocol_response = subject.get(@name, @params).protocol_response
+      protocol_response = subject.get(@name, {}).protocol_response
 
       assert_instance_of Sanford::Protocol::Response, yielded
-      assert_equal code, protocol_response.code
+      assert_equal code,    protocol_response.code
       assert_equal message, protocol_response.message
-      assert_equal data, protocol_response.data
+      assert_equal data,    protocol_response.data
     end
 
-    should "allow adding and getting responses with no params" do
-      subject.add(@name){ @response_data }
-      protocol_response = subject.get(@name).protocol_response
-      assert_equal @response_data, protocol_response.data
-    end
+    should "return a stub when adding a response" do
+      stub = subject.add(@name)
+      assert_instance_of AndSon::StoredResponses::Stub, stub
 
-    should "return a default response for a name/params that isn't configured" do
+      stub.with(@params){ @response_data }
       response = subject.get(@name, @params)
+      assert_equal @response_data, response.data
+
+      response = subject.get(@name, {})
+      assert_not_equal @response_data, response.data
+    end
+
+    should "return a default response for a service that isn't configured" do
+      response = subject.get(@name, {})
       protocol_response = response.protocol_response
+
       assert_equal 200, protocol_response.code
       assert_nil protocol_response.status.message
       assert_equal({}, protocol_response.data)
@@ -62,39 +70,79 @@ class AndSon::StoredResponses
       called = false
       subject.add(@name){ called = true }
       assert_false called
-      subject.get(@name)
+      subject.get(@name, {})
       assert_true called
     end
 
-    should "allow removing a response" do
-      subject.add(@name, @params){ @response_data }
-      protocol_response = subject.get(@name, @params).protocol_response
-      assert_equal @response_data, protocol_response.data
-
-      subject.remove(@name, @params)
-      protocol_response = subject.get(@name, @params).protocol_response
-      assert_not_equal @response_data, protocol_response.data
-    end
-
-    should "allow removing a response without params" do
+    should "allow removing a stub" do
       subject.add(@name){ @response_data }
-      protocol_response = subject.get(@name).protocol_response
+      protocol_response = subject.get(@name, {}).protocol_response
       assert_equal @response_data, protocol_response.data
 
       subject.remove(@name)
-      protocol_response = subject.get(@name).protocol_response
+      protocol_response = subject.get(@name, {}).protocol_response
       assert_not_equal @response_data, protocol_response.data
     end
 
     should "allow removing all responses" do
-      subject.add(@name, @params){ @response_data }
       subject.add(@name){ @response_data }
+      other_name = Factory.string
+      subject.add(other_name){ @response_data }
 
       subject.remove_all
-      protocol_response = subject.get(@name, @params).protocol_response
+      protocol_response = subject.get(@name, {}).protocol_response
       assert_not_equal @response_data, protocol_response.data
-      protocol_response = subject.get(@name).protocol_response
+      protocol_response = subject.get(other_name, {}).protocol_response
       assert_not_equal @response_data, protocol_response.data
+    end
+
+  end
+
+  class StubTests < UnitTests
+    desc "Stub"
+    setup do
+      @stub = Stub.new
+    end
+    subject{ @stub }
+
+    should have_readers :hash
+    should have_imeths :set_default_proc, :with, :call
+
+    should "default its default response proc" do
+      response = subject.call(@params)
+      assert_equal({}, response.data)
+    end
+
+    should "allow settings its default proc" do
+      data = Factory.string
+      subject.set_default_proc{ |r| r.data = data }
+      response = subject.call(@params)
+      assert_equal data, response.data
+    end
+
+    should "allow setting responses for specific params" do
+      response = subject.call(@params)
+      assert_equal({}, response.data)
+
+      data = Factory.string
+      subject.with(@params){ |r| r.data = data }
+      response = subject.call(@params)
+      assert_equal data, response.data
+    end
+
+    should "yield a response when a response block expects an arg" do
+      yielded = nil
+      subject.with(@params){ |r| yielded = r }
+      exp = Sanford::Protocol::Response.new(200, {})
+      assert_equal exp, subject.call(@params)
+      assert_equal exp, yielded
+    end
+
+    should "set a response data when the response block doesn't expect an arg" do
+      data = Factory.string
+      subject.with(@params){ data  }
+      exp = Sanford::Protocol::Response.new(200, data)
+      assert_equal exp, subject.call(@params)
     end
 
   end


### PR DESCRIPTION
This updates the stored response "stubbing" to allow stubbing only
a service name and having any calls made to that service generate
a response. This is useful in testing for cases where there isn't
any need to generate different responses for different params.
For example, to test how a part of code behaves when a service
returns a failing response you would stub the response to return
a 500 status code. Previously, you had to stub the service with the
params you expected to be called. This is annoying and typically
we just want to say whatever calls this service, return a 500 no
matter what params it receives. This allows for simpler tests that
focus only on the pieces that we care about and don't have extra
cruft that hides the goal of the test.

This makes the interface similar to `Assert`'s stubbing interface
and isn't backwards compatible. All the previous behavior is still
present, only the interface for using it has changed.

This also starts changes to the system tests to match our current
conventions. This moves the stored response system tests to a
client tests file and updates them to test multiple scenarios.

@kellyredding - Ready for review. I made a note that a change like this would probably be useful after seeing how we've used this in our tests. Since I'm planning on touching a lot of and-son calls I figured this would be a decent time to make this change.
