### PR TITLE
Update test client to encode requests

### DIFF
--- a/and-son.gemspec
+++ b/and-son.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency("sanford-protocol",  ["~> 0.10"])
+  gem.add_dependency("sanford-protocol",  ["~> 0.11"])
 
-  gem.add_development_dependency("assert", ["~> 2.12"])
+  gem.add_development_dependency("assert", ["~> 2.14"])
 end

--- a/lib/and-son/client.rb
+++ b/lib/and-son/client.rb
@@ -74,6 +74,11 @@ module AndSon
       params ||= {}
       callback_params = self.params_value.merge(params)
 
+      # attempt to encode (and then throw away) the request, this will error on
+      # the developer if it can't encode the request
+      request = Sanford::Protocol::Request.new(name, params)
+      Sanford::Protocol.msg_body.encode(request.to_hash)
+
       response = self.responses.get(name, params)
       self.before_call_procs.each{ |p| p.call(name, callback_params, self) }
       self.calls << Call.new(name, params, response.protocol_response)


### PR DESCRIPTION
This updates the test client to encode requests when its called.
This is a test helper to help ensure that the request is valid and
work with the real client. The test client will now build a request
and encode it. This encoded request is thrown away and not used,
its simply to make sure it can be encoded. This doesn't change any
other functionality.

This also fixes a minor bug in the system tests. Sometimes, opening
a TCP socket when stopping the test server would hang. This updates
it to manually build a TCP socket and use `connect_nonblock`. This
keeps it from blocking but furthermore allows using `IO.select`
with a timeout. This ensures if the process hangs that we can time
it out and move on. We open a connection on the server to try and
ensure we shutdown the thread correctly. The server is simple and
uses `accept` which will block the thread, keeping it from shutting
down if a client socket doesn't connect.

Closes #41

@kellyredding - Ready for review. I ran into the socket hanging when I was running the test suite many times in a row. Not sure why its hanging, but as I said its not very robust server logic so it may not be using best practices and I didn't want to invest a lot of time in reworking it.