### PR TITLE
get test suite passing in modern ruby versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'pry', "~> 0.9.0"
-gem 'bson_ext'
+gem 'bson_ext', '~>1.7'

--- a/and-son.gemspec
+++ b/and-son.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.15.1"])
+  gem.add_development_dependency("assert", ["~> 2.16.1"])
 
-  gem.add_dependency("sanford-protocol",  ["~> 0.11.0"])
+  gem.add_dependency("sanford-protocol",  ["~> 0.12.0"])
 
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -7,3 +7,14 @@ $LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
 require 'pry' # require pry for debugging (`binding.pry`)
 
 require 'test/support/factory'
+
+JOIN_SECONDS = 0.1
+
+# 1.8.7 backfills
+
+# Array#sample
+if !(a = Array.new).respond_to?(:sample) && a.respond_to?(:choice)
+  class Array
+    alias_method :sample, :choice
+  end
+end

--- a/test/support/test_server.rb
+++ b/test/support/test_server.rb
@@ -53,6 +53,7 @@ class TestServer
     def run_test_server(server, &block)
       begin
         thread = Thread.new{ server.run }
+        thread.join(JOIN_SECONDS)
         yield
       ensure
         sockaddr = Socket.pack_sockaddr_in(

--- a/test/system/client_tests.rb
+++ b/test/system/client_tests.rb
@@ -1,6 +1,7 @@
 require 'assert'
 require 'and-son/client'
 
+require 'and-son'
 require 'test/support/test_server'
 
 module AndSon::Client


### PR DESCRIPTION
This updates the gem dependencies to bring in the latest versions
(which also now work in modern ruby versions) and updates the test
suite to get things passing in modern ruby versions.

There were really only a few things that needed updating:

* I backfilled Array#sample for ruby 1.8.7 compatibility as is
  our convention.  No test code was using this logic though.
* I added a missing require to the system tests so they could
  be run on their own.  This should have been done previously
  but had been missed
* I added a join with JOIN_SECONDS constant (as is our
  convention).  This is needed to force the scheduler to let
  the thread run (this wasn't necessary in 1.8.7).

@jcredding ready for review.